### PR TITLE
Fixed bug where extra linebreaks are copied on FireFox

### DIFF
--- a/resources/ext.preToClip.js
+++ b/resources/ext.preToClip.js
@@ -16,7 +16,9 @@
 			pre.setAttribute( 'tabindex', '0' );
 		}
 
-		var clipboardText = pre.innerText;
+		var tmpNode = pre.cloneNode(true);
+		var clipboardText = tmpNode.innerText;
+		tmpNode.remove();
 		var tooltip = mw.message( 'pretoclip-button-tooltip' ).text();
 
 		var copyButton = new OO.ui.ButtonWidget( {


### PR DESCRIPTION
In FireFox extra line breaks were copied when pre.innerText is used directly. I noticed that the line breaks are not copied when you first clone the pre node.